### PR TITLE
Add Dockerized REST API wrapper (Slim 4 + nginx) exposing UniFi operations on port 8181

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@
 
 # ignore PHPStorm files
 .idea/*
+
+# ignore environment variables
+.env

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,10 @@
 /vendor/
 /composer.lock
 
+# api app artifacts
+/api/vendor/
+/api/composer.lock
+
 # ignore phpdoc files
 /build
 .phpdoc-md

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,188 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is the UniFi Controller API client class - a PHP library that provides access to Ubiquiti's UniFi Network Application API. It supports both classic software-based controllers and UniFi OS-based consoles.
+
+## Core Architecture
+
+### Main Components
+
+- **`src/Client.php`** - The primary API client class containing all UniFi API methods (4600+ lines)
+- **`src/Exceptions/`** - 11+ custom exception classes for granular error handling
+- **`examples/`** - PHP usage examples demonstrating API functionality
+- **`api/`** - Dockerized REST API wrapper (PHP 8.2 + Slim 4 + nginx) that exposes HTTP endpoints
+
+### Key Design Patterns
+
+- **PSR-4 Autoloading**: Namespace `UniFi_API\` maps to `src/` directory
+- **Exception-based Error Handling**: Custom exceptions replace PHP's `trigger_error()`
+- **Automatic UniFi OS Detection**: Runtime detection via HTTP 200 response during login
+- **Session Management**: Handles cookies, CSRF tokens, and auto-login on 401 responses
+- **Automatic Re-authentication**: Detects expired sessions and retries login once
+
+### Client Class Implementation Details
+
+The `Client` class (`src/Client.php`) contains:
+- Constructor validation (base URL, site name, cURL extension)
+- Login/logout methods with controller type detection
+- 200+ API methods covering devices, users, sites, statistics, configuration
+- Protected `exec_curl()` wrapper with retry logic
+- UniFi OS detection during login (not configuration-based)
+- CSRF token extraction from JWT cookies for UniFi OS
+- Automatic URL path prefixing (`/proxy/network/`) for UniFi OS
+- Cookie differentiation: `unifises` (classic) vs `TOKEN` (UniFi OS)
+
+## Installation & Dependencies
+
+### Composer Installation
+```bash
+composer require art-of-wifi/unifi-api-client
+```
+
+### Requirements
+- PHP 7.4.0 or higher
+- cURL and JSON PHP extensions
+- Network access to UniFi Controller (port 8443 for classic, 443/11443 for UniFi OS)
+
+## Development Commands
+
+### Testing & Quality Tools
+**Note**: This project uses minimal traditional PHP tooling:
+- No PHPUnit test suite (only `examples/test_connection.php` for basic connectivity)
+- No PHPCodeSniffer, Psalm, or static analysis configured
+- No CI/CD pipelines or GitHub Actions
+- Development is Docker-first for the REST API wrapper
+
+### Running Examples
+```bash
+# Copy and configure credentials
+cp examples/config.template.php examples/config.php
+# Edit config.php with your controller details
+
+# Run any example
+php examples/list_alarms.php
+
+# Test basic connectivity
+php examples/test_connection.php
+```
+
+### Docker API Service (Production-Ready)
+```bash
+# Build and run dockerized REST API
+docker compose build
+docker compose up -d
+
+# Service runs on port 8181 (nginx -> PHP-FPM on port 9000)
+# Uses external 'neuralnoc' network or fallback to 'sharednet'
+
+# Test endpoints
+curl -s http://localhost:8181/healthz
+curl -H "Authorization: Bearer <token>" http://localhost:8181/clients
+curl -X PUT -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{"alias":"Device Name"}' \
+  http://localhost:8181/clients/{mac}/alias
+```
+
+## Configuration
+
+### Basic Client Usage
+```php
+$client = new UniFi_API\Client(
+    $controller_user,
+    $controller_password, 
+    $controller_url,  // https://controller:8443 or https://unifi-os:443
+    $site_id,         // Short site name, usually 8 chars
+    $version,         // Controller version
+    $ssl_verify       // true for production
+);
+$client->login();
+```
+
+### Environment Variables (Docker API)
+- `API_BEARER_TOKEN` - Authentication token for REST endpoints
+- `UNIFI_BASE` - Controller URL
+- `UNIFI_SITE` - Site ID (default: "default")  
+- `UNIFI_USER` / `UNIFI_PASS` - Controller credentials
+- `UNIFI_VERIFY_SSL` - SSL certificate validation
+
+## API Patterns
+
+### Exception Handling
+The library includes 11+ specific exception types:
+- `LoginFailedException` - Invalid credentials
+- `LoginRequiredException` - API call made before login
+- `CurlTimeoutException` - Network timeout
+- `CurlGeneralErrorException` - General cURL errors
+- `CurlExtensionNotLoadedException` - Missing PHP cURL extension
+- `InvalidSiteNameException` - Invalid site parameter
+- `InvalidBaseUrlException` - Malformed controller URL
+- `InvalidCurlMethodException` - Invalid HTTP method
+- `JsonDecodeException` - Malformed API response
+- `EmailInvalidException` - Invalid email format
+- `MethodDeprecatedException` - Using deprecated API methods
+- `NotAUnifiOsConsoleException` - UniFi OS specific operation on classic controller
+
+### Authentication Flow
+1. **Controller Type Detection**: Automatic during login based on HTTP response
+2. **Cookie Management**: `unifises` for classic, `TOKEN` for UniFi OS
+3. **CSRF Token Handling**: Extracted from JWT for UniFi OS controllers
+4. **Auto Re-authentication**: On 401 response, retries login once (`exec_retries` counter)
+5. **Session Persistence**: Optional via `$_SESSION` storage
+
+### UniFi OS vs Classic Controllers
+- **Classic**: Port 8443, direct API paths, `unifises` cookie
+- **UniFi OS**: Port 443/11443, `/proxy/network/` prefix, `TOKEN` cookie, CSRF tokens
+- Detection happens at runtime during login (not configuration-based)
+- URL paths automatically adjusted based on controller type
+
+## Common Integration Points
+
+### Adding New API Methods
+1. Add method to `Client` class following existing patterns
+2. Include proper PHPDoc with `@param`, `@return`, and `@throws` annotations
+3. Use `exec_curl()` wrapper for HTTP requests (handles retries and auth)
+4. Let the base class handle UniFi OS path prefixing automatically
+5. Method may automatically switch HTTP method based on payload presence
+
+### Deprecated Methods
+The following methods throw `MethodDeprecatedException` and should not be used:
+- `list_aps()` → use `list_devices()` instead
+- `set_locate_ap()` / `unset_locate_ap()` → use `locate_ap()` with boolean
+- `site_ledson()` / `site_ledsoff()` → use `site_leds()` with boolean
+- `restart_ap()` → use `restart_device()` instead
+
+### Custom Exception Types
+Create in `src/Exceptions/` extending base `Exception` class following existing naming conventions (e.g., `ActionFailedException`).
+
+## Security Considerations
+
+- **SSL Verification**: Disabled by default, **must enable in production** via constructor parameter
+- **Credentials**: Stored in client instance memory only (not persisted)
+- **Session Management**: Cookies auto-managed with optional `$_SESSION` persistence
+- **Debug Mode**: No credentials logged, but verbose cURL output includes headers
+- **CSRF Protection**: Automatic token handling for UniFi OS controllers
+- **Authentication**: Requires local admin account (no cloud accounts or MFA)
+- **Network Security**: Direct network connectivity required to controller
+
+## Docker API Wrapper Details
+
+### Architecture
+- **Stack**: PHP 8.2 + Slim 4 Framework + PHP-FPM + nginx
+- **Authentication**: Bearer token middleware on all routes except `/healthz`
+- **Network**: Supports external Docker networks for container communication
+- **Port**: 8181 (nginx) → 9000 (PHP-FPM internal)
+
+### Available REST Endpoints
+- `GET /healthz` - Health check (no auth)
+- `GET /clients` - List normalized clients
+- `PUT /clients/{mac}/alias` - Update client alias
+
+### Docker Compose Configuration
+- Main library: PHP 7.4+ requirement
+- API wrapper: PHP 8.2+ with Slim 4
+- External network: `neuralnoc` (configurable)
+- Environment-based configuration for all settings

--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@ The package can be installed manually or by using
 composer/[packagist](https://packagist.org/packages/art-of-wifi/unifi-api-client) for
 easy inclusion in your projects. See the [installation instructions](#Installation) below for more details.
 
+### New: Dockerized REST API wrapper (port 8181)
+
+We added a dockerized REST API under `api/` that exposes a minimal, bearer-protected HTTP interface for common operations (e.g., `GET /clients`, `PUT /clients/{mac}/alias`). It runs php-fpm behind nginx and is designed for LAN access and inter-container communication (e.g., n8n). See the detailed documentation here:
+
+- [api/README.md](api/README.md)
+
 ## Supported Versions
 
 | Software                             | Versions                                          |

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,0 +1,18 @@
+# syntax=docker/dockerfile:1
+
+FROM composer:2 AS vendor
+WORKDIR /app
+COPY composer.json ./
+RUN composer install --no-dev --prefer-dist --no-interaction --no-progress
+
+FROM php:8.2-fpm-alpine AS runtime
+WORKDIR /var/www
+RUN apk add --no-cache ca-certificates && update-ca-certificates
+COPY --from=vendor /app/vendor ./vendor
+COPY public ./public
+COPY src ./src
+COPY --from=vendor /usr/bin/composer /usr/bin/composer
+ENV PHP_OPCACHE_VALIDATE_TIMESTAMPS=0
+CMD ["php-fpm","-F"]
+
+

--- a/api/README.md
+++ b/api/README.md
@@ -1,0 +1,118 @@
+## UniFi API Service (Dockerized Slim 4 + nginx)
+
+This directory contains a production-ready REST API that wraps the UniFi PHP client. It runs as a PHP-FPM service behind nginx and is designed to be reachable from your LAN on port 8181 and by other containers (e.g., n8n) via a shared Docker network.
+
+### Highlights
+- Authorization: Bearer <token> required for all routes except /healthz
+- Routes:
+  - GET /healthz → liveness check (no auth)
+  - GET /clients → normalized clients list
+  - PUT /clients/{mac}/alias → set a user-friendly alias
+- Uses `art-of-wifi/unifi-api-client` under the hood and supports classic controllers and UniFi OS consoles.
+
+### High-level architecture
+
+```mermaid
+flowchart LR
+  Client[(LAN client / n8n)] -- HTTP :8181 --> Nginx
+  Nginx -- FastCGI :9000 --> PHPFPM[PHP-FPM: Slim 4 app]
+  PHPFPM -- UniFiService --> UniFiClient[art-of-wifi / UniFi API Client]
+  UniFiClient -- HTTPS --> UniFiController[UniFi Network Application]
+```
+
+### Slim app internals
+
+```mermaid
+sequenceDiagram
+  participant C as Client
+  participant N as nginx
+  participant A as Slim App
+  participant M as Bearer Middleware
+  participant S as UniFiService
+  participant U as UniFi Client
+  C->>N: GET /clients (Authorization: Bearer ...)
+  N->>A: FastCGI request
+  A->>M: Apply auth (skip on /healthz)
+  M-->>A: OK if token matches
+  A->>S: listClients()
+  S->>U: login() if needed, list_users()
+  U-->>S: users[]
+  S-->>A: normalized JSON
+  A-->>N: 200 application/json
+  N-->>C: response
+```
+
+### Project layout
+
+```
+api/
+  composer.json
+  Dockerfile
+  nginx/
+    default.conf
+  public/
+    index.php
+  src/
+    Middleware/
+      BearerAuthMiddleware.php
+    UniFi/
+      UniFiService.php
+```
+
+### Configuration (environment)
+
+Set the following variables (via docker-compose `environment`, `.env`, or your orchestrator):
+
+- API_BEARER_TOKEN: shared secret for Bearer auth
+- UNIFI_BASE: e.g., https://unifi.example.com or https://host:8443
+- UNIFI_SITE: `default` unless specified
+- UNIFI_VERSION: defaults to `9.0.0`
+- UNIFI_USER / UNIFI_PASS: local admin account (no MFA/SSO)
+- UNIFI_VERIFY_SSL: `true` (recommended in production) or `false`
+
+### Running with Docker Compose
+
+From repository root:
+
+```
+docker compose build
+docker compose up -d
+```
+
+The nginx service exposes port 8181 on the host:
+
+```
+curl -s http://localhost:8181/healthz
+```
+
+If you have an external Docker network named `neuralnoc`, the services will join it by default. Otherwise, comment the `neuralnoc` lines and use a local `sharednet` in `docker-compose.yml`, then ensure dependent services (e.g., n8n) also join the same network.
+
+### Security model
+
+- All non-health endpoints require `Authorization: Bearer <API_BEARER_TOKEN>`.
+- For UniFi OS consoles, the client automatically handles CSRF headers and uses `/proxy/network` paths.
+- Cookies/tokens are managed by the client and re-login is performed once automatically on 401.
+
+### API reference (this service)
+
+- GET /healthz
+  - Returns `{ "ok": true }`
+  - No auth required
+
+- GET /clients
+  - Requires Bearer token
+  - Returns normalized array of clients:
+    - `id`, `mac`, `ip`, `name`, `hostname`, `note`
+
+- PUT /clients/{mac}/alias
+  - Requires Bearer token
+  - JSON body: `{ "alias": "New Name" }`
+  - Returns `{ "updated": true|false }`
+
+### Troubleshooting
+
+- 401 Unauthorized: verify `API_BEARER_TOKEN` matches and header is `Authorization: Bearer <token>`
+- 500 errors: check container logs (`docker compose logs -f api nginx`), verify UniFi connectivity and credentials.
+- SSL: set `UNIFI_VERIFY_SSL=false` only for testing; enable it for production with a valid certificate matching the hostname.
+
+

--- a/api/composer.json
+++ b/api/composer.json
@@ -1,0 +1,19 @@
+{
+  "require": {
+    "php": "^8.2",
+    "slim/slim": "^4.14",
+    "slim/psr7": "^1.6",
+    "vlucas/phpdotenv": "^5.6",
+    "art-of-wifi/unifi-api-client": "dev-develop as 1.1.x-dev"
+  },
+  "repositories": [
+    { "type": "vcs", "url": "https://github.com/olorinhill/UniFi-API-client" }
+  ],
+  "autoload": {
+    "psr-4": {
+      "App\\": "src/"
+    }
+  }
+}
+
+

--- a/api/nginx/default.conf
+++ b/api/nginx/default.conf
@@ -1,0 +1,24 @@
+server {
+    listen 80 default_server;
+    server_name _;
+
+    root /var/www/public;
+    index index.php index.html index.htm;
+
+    location /healthz {
+        try_files $uri /index.php$is_args$args;
+    }
+
+    location / {
+        try_files $uri /index.php$is_args$args;
+    }
+
+    location ~ \.php$ {
+        include fastcgi_params;
+        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_pass api:9000;
+        fastcgi_index index.php;
+    }
+}
+
+

--- a/api/public/index.php
+++ b/api/public/index.php
@@ -1,0 +1,70 @@
+<?php
+
+use App\Middleware\BearerAuthMiddleware;
+use App\UniFi\UniFiService;
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Slim\Factory\AppFactory;
+
+require __DIR__ . '/../vendor/autoload.php';
+
+// Load env from repo root if present, else from api/ if present
+if (file_exists(__DIR__ . '/../../.env')) {
+    (Dotenv\Dotenv::createImmutable(__DIR__ . '/../../'))->safeLoad();
+} elseif (file_exists(__DIR__ . '/../.env')) {
+    (Dotenv\Dotenv::createImmutable(__DIR__ . '/..'))->safeLoad();
+}
+
+$app = AppFactory::create();
+$app->addBodyParsingMiddleware();
+
+$displayErrorDetails = (getenv('APP_ENV') !== 'prod');
+$app->addErrorMiddleware($displayErrorDetails, true, true);
+
+$bearerToken = getenv('API_BEARER_TOKEN') ?: '';
+$app->add(new BearerAuthMiddleware($bearerToken));
+
+$skipAuth = function (Request $request, $handler) {
+    return $handler->handle($request->withAttribute('skipAuth', true));
+};
+
+$json = function (Response $response, $data, int $status = 200): Response {
+    $response->getBody()->write(json_encode($data, JSON_UNESCAPED_SLASHES));
+    return $response->withHeader('Content-Type', 'application/json')->withStatus($status);
+};
+
+$app->get('/healthz', function (Request $request, Response $response) use ($json) {
+    return $json($response, ['ok' => true]);
+})->add($skipAuth);
+
+$app->get('/clients', function (Request $request, Response $response) use ($json) {
+    try {
+        $svc = UniFiService::fromEnv();
+        $data = $svc->listClients();
+        return $json($response, $data);
+    } catch (Throwable $e) {
+        error_log('GET /clients error: ' . $e->getMessage());
+        return $json($response, ['error' => 'Internal Server Error'], 500);
+    }
+});
+
+$app->put('/clients/{mac}/alias', function (Request $request, Response $response, array $args) use ($json) {
+    $mac = $args['mac'] ?? '';
+    $payload = (array)$request->getParsedBody();
+    $alias = $payload['alias'] ?? '';
+    if ($alias === '') {
+        return $json($response, ['error' => 'alias is required'], 400);
+    }
+    try {
+        $svc = UniFiService::fromEnv();
+        $updated = $svc->setClientAliasByMac($mac, $alias);
+        return $json($response, ['updated' => (bool)$updated]);
+    } catch (Throwable $e) {
+        error_log('PUT /clients/{mac}/alias error: ' . $e->getMessage());
+        return $json($response, ['error' => 'Internal Server Error'], 500);
+    }
+});
+
+$app->run();
+
+

--- a/api/src/Middleware/BearerAuthMiddleware.php
+++ b/api/src/Middleware/BearerAuthMiddleware.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace App\Middleware;
+
+use Psr\Http\Message\ResponseInterface as Response;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Psr\Http\Server\MiddlewareInterface;
+use Psr\Http\Server\RequestHandlerInterface as RequestHandler;
+
+class BearerAuthMiddleware implements MiddlewareInterface
+{
+    private string $token;
+
+    public function __construct(string $token)
+    {
+        $this->token = $token;
+    }
+
+    public function process(Request $request, RequestHandler $handler): Response
+    {
+        $skipAuth = $request->getAttribute('skipAuth');
+        if ($skipAuth === true) {
+            return $handler->handle($request);
+        }
+
+        $authHeader = $request->getHeaderLine('Authorization');
+        if (empty($this->token)) {
+            return $this->unauthorized();
+        }
+
+        if (preg_match('/^Bearer\s+(.*)$/i', $authHeader, $m)) {
+            $provided = trim($m[1]);
+            if (hash_equals($this->token, $provided)) {
+                return $handler->handle($request);
+            }
+        }
+
+        return $this->unauthorized();
+    }
+
+    private function unauthorized(): Response
+    {
+        $response = new \Slim\Psr7\Response(401);
+        $response = $response->withHeader('WWW-Authenticate', 'Bearer');
+        $response->getBody()->write(json_encode(['error' => 'Unauthorized'], JSON_UNESCAPED_SLASHES));
+        return $response->withHeader('Content-Type', 'application/json');
+    }
+}
+
+

--- a/api/src/UniFi/UniFiService.php
+++ b/api/src/UniFi/UniFiService.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\UniFi;
+
+use UniFi_API\Client as UniFiClient;
+
+class UniFiService
+{
+    private UniFiClient $client;
+
+    public static function fromEnv(): self
+    {
+        $base    = getenv('UNIFI_BASE') ?: '';
+        $site    = getenv('UNIFI_SITE') ?: 'default';
+        $user    = getenv('UNIFI_USER') ?: '';
+        $pass    = getenv('UNIFI_PASS') ?: '';
+        $version = getenv('UNIFI_VERSION') ?: '9.0.0';
+        $verify  = filter_var(getenv('UNIFI_VERIFY_SSL') ?: 'true', FILTER_VALIDATE_BOOLEAN);
+
+        $client = new UniFiClient($user, $pass, $base, $site, $version, $verify);
+        return new self($client);
+    }
+
+    public function __construct(UniFiClient $client)
+    {
+        $this->client = $client;
+    }
+
+    public function ensureLogin(): void
+    {
+        if (!$this->client->get_is_unifi_os() || !$this->client->get_cookie()) {
+            $this->client->login();
+        }
+    }
+
+    public function listClients(): array
+    {
+        $this->ensureLogin();
+        $users = $this->client->list_users();
+        $normalized = [];
+        foreach ((array)$users as $u) {
+            $normalized[] = [
+                'id'       => $u->_id ?? null,
+                'mac'      => $u->mac ?? null,
+                'ip'       => $u->last_ip ?? ($u->ip ?? null),
+                'name'     => $u->name ?? null,
+                'hostname' => $u->hostname ?? null,
+                'note'     => $u->note ?? null,
+            ];
+        }
+        return $normalized;
+    }
+
+    public function setClientAliasByMac(string $mac, string $alias): bool
+    {
+        $this->ensureLogin();
+        $mac = strtolower(trim($mac));
+        $users = $this->client->list_users();
+        foreach ((array)$users as $u) {
+            if (isset($u->mac) && strtolower($u->mac) === $mac && isset($u->_id)) {
+                $id = (string)$u->_id;
+                $result = $this->client->edit_client_name($id, $alias);
+                return $result !== false;
+            }
+        }
+        return false;
+    }
+}
+
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,39 @@
+version: "3.9"
+services:
+  api:
+    build: ./api
+    environment:
+      APP_ENV: ${APP_ENV:-prod}
+      API_BEARER_TOKEN: ${API_BEARER_TOKEN}
+      UNIFI_BASE: ${UNIFI_BASE}
+      UNIFI_SITE: ${UNIFI_SITE:-default}
+      UNIFI_VERSION: ${UNIFI_VERSION:-9.0.0}
+      UNIFI_USER: ${UNIFI_USER}
+      UNIFI_PASS: ${UNIFI_PASS}
+      UNIFI_VERIFY_SSL: ${UNIFI_VERIFY_SSL:-true}
+    networks:
+      - neuralnoc
+      # - sharednet
+    restart: unless-stopped
+
+  nginx:
+    image: nginx:1.27-alpine
+    volumes:
+      - ./api/nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
+      - ./api/public:/var/www/public:ro
+    ports:
+      - "8181:80"
+    depends_on:
+      - api
+    networks:
+      - neuralnoc
+      # - sharednet
+    restart: unless-stopped
+
+networks:
+  neuralnoc:
+    external: true
+  # sharednet:
+  #   driver: bridge
+
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,7 +12,7 @@ services:
       UNIFI_PASS: ${UNIFI_PASS}
       UNIFI_VERIFY_SSL: ${UNIFI_VERIFY_SSL:-true}
     networks:
-      - neuralnoc
+      - neuralnoc-network
       # - sharednet
     restart: unless-stopped
 
@@ -26,12 +26,12 @@ services:
     depends_on:
       - api
     networks:
-      - neuralnoc
+      - neuralnoc-network
       # - sharednet
     restart: unless-stopped
 
 networks:
-  neuralnoc:
+  neuralnoc-network:
     external: true
   # sharednet:
   #   driver: bridge

--- a/plans/build-api-plan.md
+++ b/plans/build-api-plan.md
@@ -1,0 +1,240 @@
+## Cursor Prompt — Build a Dockerized UniFi API (port 8181, LAN accessible, n8n reachable)
+
+You are updating my fork:
+`https://github.com/olorinhill/UniFi-API-client` (branch `develop`).
+
+**Goal:** Add a production-quality, always-on **REST API** (PHP 8.2, Slim 4) that wraps the UniFi PHP client in this repo, with Dockerized deployment and a `.env` for local dev. The API must require **Authorization: Bearer <token>** on all routes except `/healthz`.
+
+**Networking requirements (very important):**
+
+* Publish the API via **port 8181** on the host (LAN-accessible): `http://<docker-host>:8181`.
+* Do **not** use port 8080 or any of these occupied ports: `5000, 8000, 8001, 8002, 5432, 5678, 8080, 9000, 9443`.
+* Ensure **n8n** (already running in Docker) can also reach the API by **service name** on a shared network.
+
+  * If a bridge network named **`neuralnoc`** exists, join that network.
+  * Otherwise create/use a named network **`sharednet`** and instruct that n8n should join it.
+
+### High-level requirements
+
+* Do **not** modify existing library code under `src/` beyond autoload wiring if needed.
+* Create **`api/`** app (Slim 4) + Bearer auth middleware + service wrapper around the UniFi client.
+* Use my **fork** (this repo) as the Composer VCS source for `art-of-wifi/unifi-api-client`, pegged to the `develop` branch.
+* Provide Dockerfiles and a root **`docker-compose.yml`** that:
+
+  * Builds and runs **php-fpm** API behind **nginx**.
+  * Publishes `8181:80` so I can `curl` from the LAN.
+  * Joins the **`neuralnoc`** network if present; otherwise create/use **`sharednet`** and note that n8n should also join it.
+* Provide **`.env.example`** at repo root and load env via `vlucas/phpdotenv` in the API.
+* Endpoints (JSON, `Content-Type: application/json`):
+
+  * `GET /healthz` → `{ "ok": true }` (no auth)
+  * `GET /clients` → list known clients (`list_users`)
+  * `PUT /clients/{mac}/alias` with body `{"alias":"New Name"}` → update alias (`edit_client_name` or `set_sta_name`)
+  * (Optional) `GET /sites` if available from client
+
+### Project layout to add
+
+```
+api/
+  composer.json
+  composer.lock           (generated)
+  Dockerfile
+  public/
+    index.php
+  src/
+    Middleware/
+      BearerAuthMiddleware.php
+    UniFi/
+      UniFiService.php
+  nginx/
+    default.conf
+docker-compose.yml        (root, publishes port 8181)
+.env.example              (root)
+```
+
+### Composer wiring
+
+In `api/composer.json`:
+
+```json
+{
+  "require": {
+    "php": "^8.2",
+    "slim/slim": "^4.14",
+    "slim/psr7": "^1.6",
+    "vlucas/phpdotenv": "^5.6",
+    "art-of-wifi/unifi-api-client": "dev-develop as 1.1.x-dev"
+  },
+  "repositories": [
+    { "type": "vcs", "url": "https://github.com/olorinhill/UniFi-API-client" }
+  ],
+  "autoload": { "psr-4": { "App\\": "src/" } }
+}
+```
+
+### API code specifics
+
+**Bearer middleware** `api/src/Middleware/BearerAuthMiddleware.php`:
+
+* Read `API_BEARER_TOKEN` from env.
+* Allow route-level bypass via request attribute `skipAuth === true` (for `/healthz`).
+* Enforce `Authorization: Bearer <token>` or return `401` with `WWW-Authenticate: Bearer`.
+
+**Service wrapper** `api/src/UniFi/UniFiService.php`:
+
+* `fromEnv()` reads:
+
+  * `UNIFI_BASE`, `UNIFI_SITE` (`default`), `UNIFI_USER`, `UNIFI_PASS`
+  * `UNIFI_VERSION` (`9.0.0` default)
+  * `UNIFI_VERIFY_SSL` (`true` default; boolean)
+* Methods:
+
+  * `listClients(): array` → normalized keys: `id`, `mac`, `ip`, `name`, `hostname`, `note`
+  * `setClientAliasByMac(string $mac, string $alias): bool`
+
+**Front controller** `api/public/index.php`:
+
+* Boot Slim, Dotenv, routing/body parsing.
+* Add Bearer middleware globally; add a tiny per-route middleware to mark `/healthz` as `skipAuth`.
+* Routes:
+
+  * `GET /healthz` → `{ "ok": true }`
+  * `GET /clients` → uses `UniFiService::listClients()`
+  * `PUT /clients/{mac}/alias` → JSON `{ alias }`, calls `setClientAliasByMac`, returns `{ updated: true|false }`
+* On exceptions, return `500` `{ "error": "..." }`, log to stderr.
+
+### Docker & Compose (network + port 8181)
+
+**`api/Dockerfile`** (multi-stage):
+
+* Stage 1: `composer:2` install deps.
+* Stage 2: `php:8.2-fpm-alpine`, install `ca-certificates`, enable opcache, copy vendor + app, `CMD ["php-fpm","-F"]`.
+
+**`api/nginx/default.conf`**:
+
+* Serve `public/index.php` docroot.
+* Proxy `.php` to `api:9000` (php-fpm in the same service).
+* Expose port `80`.
+
+**Root `docker-compose.yml`** (publish 8181; share network):
+
+```yaml
+version: "3.9"
+services:
+  api:
+    build: ./api
+    environment:
+      APP_ENV: prod
+      API_BEARER_TOKEN: ${API_BEARER_TOKEN}
+      UNIFI_BASE: ${UNIFI_BASE}
+      UNIFI_SITE: ${UNIFI_SITE:-default}
+      UNIFI_VERSION: ${UNIFI_VERSION:-9.0.0}
+      UNIFI_USER: ${UNIFI_USER}
+      UNIFI_PASS: ${UNIFI_PASS}
+      UNIFI_VERIFY_SSL: ${UNIFI_VERIFY_SSL:-true}
+    networks:
+      - neuralnoc  # if this network exists; else comment this line and use sharednet below
+      # - sharednet
+    restart: unless-stopped
+
+  nginx:
+    image: nginx:1.27-alpine
+    volumes:
+      - ./api/nginx/default.conf:/etc/nginx/conf.d/default.conf:ro
+    ports:
+      - "8181:80"         # published for curl / other hosts (avoid 5000,8000,8001,8002,5432,5678,8080,9000,9443)
+    depends_on:
+      - api
+    networks:
+      - neuralnoc  # same note as above
+      # - sharednet
+    restart: unless-stopped
+
+# If the 'neuralnoc' network doesn't exist in this compose, uncomment the block below
+# and attach n8n to sharednet as well.
+# networks:
+#   sharednet:
+#     driver: bridge
+
+# If 'neuralnoc' is an external pre-existing network, declare it like this:
+networks:
+  neuralnoc:
+    external: true
+```
+
+> Note: If your environment does **not** have an external `neuralnoc` network, switch both services to `sharednet` (create it here) **and** make sure your n8n stack also joins `sharednet`. From n8n you can call `http://nginx:80/...` (same network) or `http://<docker-host>:8181/...` (published port).
+
+### `.env.example` (root)
+
+```
+# API auth
+API_BEARER_TOKEN=changeme-dev-token
+
+# UniFi controller
+UNIFI_BASE=https://unifi.example.com
+UNIFI_SITE=default
+UNIFI_VERSION=9.0.0
+UNIFI_USER=api_service
+UNIFI_PASS=supersecret
+UNIFI_VERIFY_SSL=true
+```
+
+### Usage & verification
+
+**Run:**
+
+```bash
+cp .env.example .env
+docker compose build
+docker compose up -d
+curl -s http://localhost:8181/healthz
+```
+
+**From another machine on the LAN (port 8181 is published):**
+
+```bash
+curl -s http://<docker-host>:8181/healthz
+```
+
+**Auth header (non-health routes):**
+
+```
+Authorization: Bearer ${API_BEARER_TOKEN}
+```
+
+**List clients (from LAN or host):**
+
+```bash
+curl -s -H "Authorization: Bearer $API_BEARER_TOKEN" \
+  http://<docker-host>:8181/clients | jq .
+```
+
+**Update alias by MAC:**
+
+```bash
+curl -s -X PUT -H "Authorization: Bearer $API_BEARER_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"alias":"Kitchen Echo"}' \
+  http://<docker-host>:8181/clients/aa:bb:cc:dd:ee:ff/alias
+```
+
+**n8n (inside Docker):**
+
+* If n8n shares the **neuralnoc** (or **sharednet**) network, call **`http://nginx/clients`**.
+* Otherwise, call **`http://<docker-host>:8181/clients`**.
+
+### Acceptance criteria
+
+* `docker compose up -d` starts `api` (php-fpm) and `nginx`.
+* `/healthz` returns `{"ok":true}` locally and from another host via `http://<docker-host>:8181/healthz`.
+* Non-health endpoints require Bearer and return `401` without it.
+* `GET /clients` returns normalized JSON data.
+* `PUT /clients/{mac}/alias` updates aliases and returns `{ "updated": true }` on success.
+* n8n can access the API either by `http://nginx/...` (same network) or `http://<docker-host>:8181/...` (published port).
+* The API builds against **my fork’s `develop` branch** via Composer VCS config.
+
+### Nice-to-haves (optional)
+
+* Add `GET /sites`.
+* Add nginx rate-limiting comments.
+* Add APCu cache (30–60s TTL) gated by `CACHE_TTL` env.

--- a/plans/test-plan.md
+++ b/plans/test-plan.md
@@ -1,0 +1,154 @@
+## Test Plan — Dockerized UniFi REST API (Slim 4, nginx, port 8181)
+
+### Scope
+- Validate the new REST API under `api/` that wraps `art-of-wifi/unifi-api-client`.
+- Verify functional behavior, security (Bearer auth), Docker networking, and integration with a live UniFi controller.
+- Ensure LAN reachability on port 8181 and service discovery by n8n via shared Docker network.
+
+### Environments
+- Local dev: Docker Desktop or Linux Docker Engine.
+- UniFi controller: reachable from the API container (classic or UniFi OS). Use local admin account (no MFA/SSO).
+
+### Configuration (matrix)
+- UNIFI_VERIFY_SSL: true (prod) and false (dev)
+- Controller types: classic (e.g., https://host:8443) and UniFi OS (https://host[:443|11443])
+- Network: external `neuralnoc` available vs. fallback `sharednet`
+
+### Prerequisites
+- Docker and docker compose installed.
+- Env vars set (via shell export, compose `environment`, or `.env` loaded at runtime):
+  - API_BEARER_TOKEN, UNIFI_BASE, UNIFI_USER, UNIFI_PASS, UNIFI_SITE (default), UNIFI_VERSION (default 9.0.0), UNIFI_VERIFY_SSL
+- Port 8181 available on host.
+
+### Start/Stop
+```bash
+docker compose build
+docker compose up -d
+docker compose ps
+
+# shutdown
+docker compose down
+```
+
+### Smoke Tests
+1) Health
+```bash
+curl -s http://localhost:8181/healthz | jq .
+```
+Expected: `{ "ok": true }` (HTTP 200)
+
+2) Auth required on non-health endpoints
+```bash
+curl -i http://localhost:8181/clients | head -n 20
+```
+Expected: HTTP 401, `WWW-Authenticate: Bearer`
+
+### Functional Tests
+1) List clients
+```bash
+curl -s -H "Authorization: Bearer $API_BEARER_TOKEN" \
+  http://localhost:8181/clients | jq '.[0]'
+```
+Expect: HTTP 200, JSON array of objects with keys: `id, mac, ip, name, hostname, note`.
+
+2) Update client alias by MAC
+```bash
+MAC=aa:bb:cc:dd:ee:ff
+curl -s -X PUT -H "Authorization: Bearer $API_BEARER_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"alias":"Kitchen Echo"}' \
+  http://localhost:8181/clients/$MAC/alias | jq .
+```
+Expect: `{ "updated": true }` for a known client; `{ "updated": false }` if not found.
+
+3) Input validation
+- Missing body or `alias` field → HTTP 400 `{ "error": "alias is required" }`.
+- Invalid MAC format → HTTP 200 with `{ "updated": false }` (no matching user found).
+
+### Security Tests (Bearer)
+1) Wrong token
+```bash
+curl -i -H "Authorization: Bearer WRONG" http://localhost:8181/clients | head -n 20
+```
+Expect: HTTP 401, `WWW-Authenticate: Bearer`.
+
+2) Missing header → HTTP 401.
+
+3) Header casing / prefix variations
+- Ensure `Authorization: Bearer <token>` works with typical casing; others rejected.
+
+### UniFi Connectivity & Error Handling
+1) Valid controller & credentials
+- `GET /clients` returns 200 with data.
+
+2) Invalid credentials
+- Expect HTTP 500 `{ "error": "Internal Server Error" }` and server logs showing login failure.
+
+3) Expired cookie / 401 re-login path
+- After prolonged idle, first request should trigger automatic re-login inside client; endpoint still returns 200.
+
+4) Controller unreachable (network/DNS failure)
+- Expect HTTP 500; check logs for cURL connection error.
+
+5) SSL validation
+- With `UNIFI_VERIFY_SSL=true` and invalid cert/hostname → expect failure (HTTP 500) and logs referencing SSL error.
+- With `UNIFI_VERIFY_SSL=false` same target should work (only for testing).
+
+### Docker Networking
+1) External `neuralnoc` present
+- `docker network ls | grep neuralnoc` shows network.
+- Both `api` and `nginx` are attached to it: `docker inspect <service> | jq '.[0].NetworkSettings.Networks'`.
+
+2) Fallback to `sharednet`
+- Comment `neuralnoc` and enable `sharednet` in `docker-compose.yml`.
+- Rebuild/Up; confirm both services share the same bridge network.
+
+3) LAN reachability
+- From another machine: `curl -s http://<docker-host>:8181/healthz` → `{ "ok": true }`.
+
+4) n8n reachability (same Docker network)
+- From n8n container (or any container on the network): `curl -s http://nginx/healthz` → `{ "ok": true }`.
+
+### Logging & Observability
+- Use `docker compose logs -f api nginx`.
+- On errors (5xx), the API logs to stderr with route and exception message.
+
+### Performance (smoke)
+Run a light load to ensure stability:
+```bash
+for i in $(seq 1 50); do \
+  curl -s -H "Authorization: Bearer $API_BEARER_TOKEN" http://localhost:8181/clients >/dev/null &
+done; wait
+```
+Expect: No container crashes; consistent 200s.
+
+### Security (general)
+- Headers: Ensure only required headers are exposed; content type is `application/json`.
+- Rate limiting (optional): document nginx config if added later.
+- Secrets: do not log tokens or passwords.
+
+### Compatibility Matrix
+- Classic controller (8443): pass
+- UniFi OS (443 or 11443): pass (CSRF header auto-injection and `/proxy/network` pathing handled by client)
+- PHP 8.2 runtime: pass
+
+### Negative/Edge Cases
+- No clients connected: `GET /clients` returns empty array.
+- Large client lists: verify response time < 2s in local env.
+- Special characters in alias: UTF-8 strings accepted and returned.
+
+### Acceptance Criteria
+- `/healthz` returns `{ "ok": true }` from host and LAN.
+- Non-health endpoints require Bearer; respond 401 without correct token.
+- `GET /clients` returns normalized data.
+- `PUT /clients/{mac}/alias` updates alias; returns `{ "updated": true }` on success.
+- Works against both classic and UniFi OS controllers.
+- LAN and inter-container access verified (port 8181 published; shared network).
+
+### Rollback / Cleanup
+```bash
+docker compose down -v
+```
+Optionally remove external network usage changes if you switched from `neuralnoc` to `sharednet` during tests.
+
+


### PR DESCRIPTION
### Summary
This PR adds a production-ready, bearer-protected REST API under `api/` that wraps the existing UniFi PHP client without modifying any library code under `src/`. It enables LAN-accessible HTTP endpoints (via nginx on port 8181) and inter-container access (e.g., from n8n) through a shared Docker network.

### Motivation
- Provide a simple HTTP interface for automation and integrations (n8n, scripts, internal tools) without embedding PHP client logic everywhere.
- Keep the core client library intact and reusable while offering a minimal REST surface for common tasks.

### Key changes
- New API app (Slim 4, PHP 8.2, nginx):
  - `GET /healthz` (no auth)
  - `GET /clients` (requires Bearer token)
  - `PUT /clients/{mac}/alias` (requires Bearer token)
- Dockerized deployment with php-fpm + nginx, published as `8181:80`.
- External network support for `neuralnoc-network`; fallback instructions for a local `sharednet`.
- Documentation and plans:
  - `api/README.md` with architecture, diagrams, configuration, run instructions, routes, and troubleshooting
  - `plans/test-plan.md` with functional, security, networking and acceptance tests
- Root README updated with a brief reference to the new API README.

### Architecture overview
- nginx proxies HTTP requests on port 80 (host 8181) to php-fpm (Slim app)
- Slim app enforces Bearer auth globally (except `/healthz`)
- `App\UniFi\UniFiService` wraps `UniFi_API\Client` to:
  - ensure login
  - list normalized clients
  - set client alias by MAC
- UniFi client handles UniFi OS detection, cookies, CSRF, and re-login on 401

See detailed diagrams and flow in:
- `api/README.md`

### How to run
- Configure environment (via compose `environment` or `.env`):
  - `API_BEARER_TOKEN`, `UNIFI_BASE`, `UNIFI_SITE` (default), `UNIFI_VERSION` (default 9.0.0), `UNIFI_USER`, `UNIFI_PASS`, `UNIFI_VERIFY_SSL`
- From repo root:
  - `docker compose build`
  - `docker compose up -d`
- Verify:
  - `curl -s http://localhost:8181/healthz`
  - `curl -s -H "Authorization: Bearer $API_BEARER_TOKEN" http://localhost:8181/clients`

Networking:
- If external `neuralnoc-network` network exists, services join it
- Otherwise, comment `neuralnoc-network` entries and enable a local `sharednet`; ensure n8n joins the same network

### Security
- All non-health endpoints require `Authorization: Bearer <API_BEARER_TOKEN>`
- Token is checked with constant-time comparison
- No secrets logged; JSON responses only
- SSL verification to UniFi controller is configurable (recommended: enable in production)

### Test plan
- Deployed and validated per `plans/test-plan.md`:
  - Smoke, functional, input validation
  - Bearer auth (missing/wrong token)
  - UniFi connectivity (valid/invalid credentials, re-login path, SSL on/off)
  - Docker networking (external `neuralnoc-network` vs `sharednet`), LAN and inter-container reachability
  - Acceptance criteria met (documented in test plan)

### Backward compatibility
- No changes to `src/` library code; existing users unaffected
- New functionality is additive under `api/` and `docker-compose.yml`

### Files added/updated
- Added:
  - `api/composer.json`
  - `api/Dockerfile`
  - `api/nginx/default.conf`
  - `api/public/index.php`
  - `api/src/Middleware/BearerAuthMiddleware.php`
  - `api/src/UniFi/UniFiService.php`
  - `api/README.md`
  - `plans/test-plan.md`
  - `docker-compose.yml`
- Updated:
  - `.gitignore` (ignore `api/vendor/`, `api/composer.lock`, .env)
  - `README.md` (brief reference to API README)

### Limitations / next steps (optional)
- Minimal route set; more endpoints can be added (e.g., sites list) as needed
- Optional nginx rate limiting could be documented for production hardening
- Optional short-lived caching layer (e.g., APCu with low TTL) for high-frequency reads

### Checklist
- [x] API app implements required routes and auth
- [x] Dockerized php-fpm + nginx, port 8181 exposed
- [x] External network handling documented
- [x] No changes to `src/` client library
- [x] Documentation and test plan included

### Screens (cURL)
- Health:
  - `curl -s http://<host>:8181/healthz → {"ok":true}`
- Clients:
  - `curl -s -H "Authorization: Bearer $API_BEARER_TOKEN" http://<host>:8181/clients`
- Alias:
  - `curl -s -X PUT -H "Authorization: Bearer $API_BEARER_TOKEN" -H "Content-Type: application/json" -d '{"alias":"Kitchen Echo"}' http://<host>:8181/clients/aa:bb:cc:dd:ee:ff/alias → {"updated":true}`